### PR TITLE
Fix source maps having incorrect line numbers

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -7,6 +7,7 @@
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
         "baseUrl": ".",
+        "sourceMap": true,
         "types": [
             "webpack-env",
             "jest"


### PR DESCRIPTION
Without this option enabled, generated source maps have incorrect line numbers and cause debuggers to not work correctly.