### PR TITLE
Store DAD result in HL register pair

### DIFF
--- a/web/src/emulator/index.ts
+++ b/web/src/emulator/index.ts
@@ -1286,7 +1286,7 @@ export class Emulator {
         } else {
             clrb(this.flags, FlagsIndex.Carry)
         }
-
+        this.setrp(RegisterPair.H, high(result), low(result))
         this.pc += 1
         this.cycles += 3
     }


### PR DESCRIPTION
This PR addresses a bug whereby the DAD result is not stored. 